### PR TITLE
Update golden tests output for kube-libsonnet v1.19.0

### DIFF
--- a/tests/golden/defaults/acme-dns/acme-dns/acme-dns/40_ingress.yaml
+++ b/tests/golden/defaults/acme-dns/acme-dns/acme-dns/40_ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -13,8 +13,10 @@ spec:
       http:
         paths:
           - backend:
-              serviceName: acme-dns-api
-              servicePort: 8080
+              service:
+                name: acme-dns-api
+                port:
+                  name: api
             path: /
             pathType: Prefix
   tls:


### PR DESCRIPTION
kube-libsonnet v1.19.0 uses `networking.k8s.io/v1` which changes the golden test output.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
