### PR TITLE
Move multi-instance advertisement to `_metadata`

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -1,7 +1,7 @@
 parameters:
   acme_dns:
-    =_metadata: {}
-    multi_instance: true
+    =_metadata:
+      multi_instance: true
     namespace: syn-acme-dns-${_instance}
 
     images:


### PR DESCRIPTION
This adheres to the new format for advertising multi-instance support, see the Commodore [component instantiation documentation][1] and [deprecation notices][2].

[1]: https://syn.tools/commodore/reference/architecture.html#_component_instantiation
[2]: https://syn.tools/commodore/reference/deprecation-notices.html#_multi_instance_top_level




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
