### PR TITLE
caddy long-form flags must now use double-hyphen 

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -108,7 +108,7 @@ local deployment = kube.Deployment('acme-dns') {
           },
           caddy: kube.Container('caddy') {
             image: common.image(params.images.caddy),
-            command: [ 'caddy', 'run', '-config', '/etc/caddy/caddy.json' ],
+            command: [ 'caddy', 'run', '--config', '/etc/caddy/caddy.json' ],
             ports_: {
               api: {
                 protocol: 'TCP',

--- a/tests/golden/defaults/acme-dns/acme-dns/acme-dns/20_deployment.yaml
+++ b/tests/golden/defaults/acme-dns/acme-dns/acme-dns/20_deployment.yaml
@@ -65,7 +65,7 @@ spec:
           command:
             - caddy
             - run
-            - -config
+            - --config
             - /etc/caddy/caddy.json
           env: []
           image: docker.io/caddy/caddy:alpine


### PR DESCRIPTION
In the caddy release 2.6.0 [1] there was an breaking change which long-form single hyphen cli flags (e.q. -config) are no longer supported. Therefore we have to switch to double-hyphen (e.q. --config)

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [ x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

[1] https://github.com/caddyserver/caddy/releases/tag/v2.6.0