### PR TITLE
Use static versions for `acme-dns` and `caddy` container images

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -9,11 +9,11 @@ parameters:
       acme-dns:
         registry: docker.io
         repository: joohoi/acme-dns
-        tag: latest
+        tag: v1.0
       caddy:
         registry: docker.io
         repository: caddy/caddy
-        tag: alpine
+        tag: 2.6.1-alpine
       sqlite:
         registry: docker.io
         repository: nouchka/sqlite3

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -17,6 +17,9 @@ parameters:
       sqlite:
         registry: docker.io
         repository: nouchka/sqlite3
+        # We use the sqlite3 image for K8up-based backups. Unfortunately
+        # there's no tags other than latest for the nouchka/sqlite3 image, so
+        # we're using latest here.
         tag: latest
 
     api:

--- a/tests/golden/defaults/acme-dns/acme-dns/acme-dns/20_deployment.yaml
+++ b/tests/golden/defaults/acme-dns/acme-dns/acme-dns/20_deployment.yaml
@@ -28,8 +28,8 @@ spec:
       containers:
         - args: []
           env: []
-          image: docker.io/joohoi/acme-dns:latest
-          imagePullPolicy: Always
+          image: docker.io/joohoi/acme-dns:v1.0
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
             httpGet:
@@ -68,7 +68,7 @@ spec:
             - --config
             - /etc/caddy/caddy.json
           env: []
-          image: docker.io/caddy/caddy:alpine
+          image: docker.io/caddy/caddy:2.6.1-alpine
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
@@ -109,7 +109,7 @@ spec:
           envFrom:
             - secretRef:
                 name: acmedns-basicauth
-          image: docker.io/caddy/caddy:alpine
+          image: docker.io/caddy/caddy:2.6.1-alpine
           imagePullPolicy: IfNotPresent
           name: render-caddy-config
           ports: []


### PR DESCRIPTION
We shouldn't use `latest` and related tags as default versions for container images. For the `sqlite3` image the only available tag is `latest` (see https://hub.docker.com/r/nouchka/sqlite3/tags) so we leave that for now.

Noticed while reviewing #41 

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
