### PR TITLE
Fix `caddy` command line in init container to work with Caddy v2.6

### DIFF
--- a/component/caddy-config.libsonnet
+++ b/component/caddy-config.libsonnet
@@ -83,7 +83,8 @@ local base_config = {
   configmap: kube.ConfigMap(common.caddy.cm_name) {
     data: {
       'render-config': |||
-        pw=`caddy hash-password -plaintext ${BASIC_AUTH_PASSWORD}`
+        set -e
+        pw=`caddy hash-password --plaintext ${BASIC_AUTH_PASSWORD}`
         sed -e "s/THE_PASSWORD/${pw}/" /etc/caddy/caddy.json.tpl > /etc/caddy.out/caddy.json
       |||,
       'caddy.json.tpl': '%s' % [ base_config ],

--- a/tests/golden/defaults/acme-dns/acme-dns/acme-dns/10_config.yaml
+++ b/tests/golden/defaults/acme-dns/acme-dns/acme-dns/10_config.yaml
@@ -62,7 +62,9 @@ data:
     {"handle": [{"body": "OK", "handler": "static_response", "status_code": 200}],
     "match": [{"path": ["/healthz"]}]}, {"handle": [{"handler": "reverse_proxy", "upstreams":
     [{"dial": "127.0.0.1:8000"}]}]}]}}}}}'
-  render-config: 'pw=`caddy hash-password -plaintext ${BASIC_AUTH_PASSWORD}`
+  render-config: 'set -e
+
+    pw=`caddy hash-password --plaintext ${BASIC_AUTH_PASSWORD}`
 
     sed -e "s/THE_PASSWORD/${pw}/" /etc/caddy/caddy.json.tpl > /etc/caddy.out/caddy.json
 

--- a/tests/golden/defaults/acme-dns/acme-dns/acme-dns/20_deployment.yaml
+++ b/tests/golden/defaults/acme-dns/acme-dns/acme-dns/20_deployment.yaml
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        acme-dns.syn.tools/config-hash: 589762392e4ab772b0a0f78dcaf597f1
+        acme-dns.syn.tools/config-hash: 56d9e9226cc4305ac6bbe74574a0cd92
       labels:
         name: acme-dns
     spec:


### PR DESCRIPTION
Also add `set -e` so the init container exits with an error if any commands fail. Follow-up to #41 

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
