### PR TITLE
Add make target and GitHub action to validate Caddy config

### DIFF
--- a/.github/workflows/validate-caddy-config.yaml
+++ b/.github/workflows/validate-caddy-config.yaml
@@ -1,0 +1,16 @@
+name: Validate generated Caddy config
+on:
+  pull_request:
+    branches:
+      - master
+
+env:
+  COMPONENT_NAME: acme-dns
+
+jobs:
+  validate_caddy_config:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate Caddy config
+        run: make lint_validate_caddy_config

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ SHELL := bash
 .SUFFIXES:
 
 include Makefile.vars.mk
+include Makefile.custom.mk
 
 .PHONY: help
 help: ## Show this help

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -1,0 +1,5 @@
+.PHONY: lint_validate_caddy_config
+lint_validate_caddy_config: ## Validate generated Caddy config
+	$(eval CADDY_IMAGE := $(shell yq '.parameters.acme_dns.images.caddy|"\(.registry)/\(.repository):\(.tag)"' class/defaults.yml))
+	$(eval CADDY_CONFIG := $(shell yq 'select(.metadata.name=="acmedns-caddy-config")|.data."caddy.json.tpl"' tests/golden/defaults/acme-dns/acme-dns/acme-dns/10_config.yaml))
+	$(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) -e CADDY_CONFIG='$(CADDY_CONFIG)' $(CADDY_IMAGE) sh -c 'echo $${CADDY_CONFIG} | sed -e "s#THE_PASSWORD#$$(caddy hash-password --plaintext test)#" | caddy validate --config -'


### PR DESCRIPTION
The make target extracts the Caddy image specified in `class/defaults.yml` and uses it to validate the checked in Caddy config from the default golden test.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
